### PR TITLE
Fix deprecated GitHub Actions versions blocking GH Pages deploy

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -25,9 +25,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.21
+      MDBOOK_VERSION: 0.4.40
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
@@ -41,9 +41,9 @@ jobs:
         run: bash ./scripts/mdbook_cleanup.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./book
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v3 → v4
- Bumps `actions/configure-pages` v3 → v5
- Bumps `actions/upload-pages-artifact` v2 → v3 (root cause — internally used deprecated `upload-artifact@v3`)
- Bumps `actions/deploy-pages` v2 → v4
- Updates mdBook from 0.4.21 → 0.4.40

## Problem

The Deploy mdBook to GH Pages workflow has been failing in ~3 seconds on every push to `main`. GitHub auto-fails any workflow that uses `actions/upload-artifact@v3`, which was deprecated in April 2024. `upload-pages-artifact@v2` depends on it internally.

## Test plan

- [ ] Verify the `Deploy mdBook to GH Pages` workflow passes on this PR branch
- [ ] Confirm GH Pages deploys successfully after merge to `main`