### PR TITLE
Fix deprecated GitHub Actions versions in Scorecard workflow

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -25,9 +25,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.21
+      MDBOOK_VERSION: 0.4.40
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
@@ -41,9 +41,9 @@ jobs:
         run: bash ./scripts/mdbook_cleanup.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./book
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,6 +24,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'workflow_dispatch'
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -35,12 +36,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
@@ -62,7 +63,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: SARIF file
           path: results.sarif
@@ -70,6 +71,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,9 @@ on:
   push:
     branches: [ "main" ]
 
+  # Allows to run this workflow manually from the actions tab
+  workflow_dispatch:
+
 # Declare default permissions as read only.
 permissions: read-all
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- `actions/checkout` v3.1.0 → v6.0.2 (Node.js 24, ahead of June 16 deadline)
- `ossf/scorecard-action` v2.1.2 → v2.4.1
- `actions/upload-artifact` v3.1.0 → v4.6.1 ← **root cause of startup_failure**
- `github/codeql-action/upload-sarif` v2.2.4 → v3.36.0
- Added `workflow_dispatch` trigger for manual runs
- Added job-level `if:` condition restricting runs to default branch or manual dispatch (aligns with official template)

Also upgrades `actions/checkout` v4 → v6.0.2 in `mdbook.yml`.

## Problem

The Scorecard workflow has been failing at startup every week since at least April 2026 — two compounding issues:
1. `actions/upload-artifact@v3` (deprecated April 2024) — auto-fails any workflow referencing it
2. `ossf/scorecard-action` was not in the repo's allowed actions list — GitHub blocked it before any runner started, producing a 0-second startup_failure with no logs

The second issue required adding `ossf/scorecard-action@*` to the repo's Actions allowlist (Settings → Actions → General → allowed patterns).

## Testing Notes

Triggered `workflow_dispatch` on this branch — run: https://github.com/OWASP/owasp-istg/actions/runs/26673537621

- No more `startup_failure` — job reached the analysis step ✅
- `ossf/scorecard-action` loads and runs successfully ✅
- `Run analysis` exits with `Only the default branch main is supported` — this is the action's own hard restriction, not a bug. The workflow will complete fully after merge to `main` ✅

## Test plan

- [ ] Verify the `Scorecard supply-chain security` workflow passes on the next scheduled run or push to `main` after merge
- [ ] Confirm SARIF results appear in the Security → Code scanning tab