### PR TITLE
Add binary compilation hardening test cases (ISTG-FW-INFO-004, ISTG-MEM-INFO-005)

### DIFF
--- a/checklists/checklist.md
+++ b/checklists/checklist.md
@@ -24,6 +24,7 @@ Note: The `Status` column can be set for values similar to "Pass", "Fail", "N/A"
 |ISTG-MEM-INFO-002|Disclosure of Implementation Details|||
 |ISTG-MEM-INFO-003|Disclosure of Ecosystem Details|||
 |ISTG-MEM-INFO-004|Disclosure of User Data|||
+|ISTG-MEM-INFO-005|Insecure Binary Compilation Options|||
 |**ISTG-MEM-SCRT**|**Secrets**|||
 |ISTG-MEM-SCRT-001|Unencrypted Storage of Secrets|||
 |**ISTG-MEM-CRYPT**|**Cryptography**|||
@@ -36,6 +37,7 @@ Note: The `Status` column can be set for values similar to "Pass", "Fail", "N/A"
 |ISTG-FW-INFO-001|Disclosure of Source Code and Binaries|||
 |ISTG-FW-INFO-002|Disclosure of Implementation Details|||
 |ISTG-FW-INFO-003|Disclosure of Ecosystem Details|||
+|ISTG-FW-INFO-004|Insecure Binary Compilation Options|||
 |**ISTG-FW-CONF**|**Configuration and Patch Management**|||
 |ISTG-FW-CONF-001|Usage of Outdated Software|||
 |ISTG-FW-CONF-002|Presence of Unnecessary Software and Functionalities|||

--- a/src/03_test_cases/firmware/README.md
+++ b/src/03_test_cases/firmware/README.md
@@ -197,7 +197,7 @@ For this test case, data from the following available sources was consolidated:
 
 **Summary**
 
-Compiled binaries within IoT firmware may lack standard exploit mitigation features that are enabled through compiler and linker security flags. Security hardening features such as Position Independent Executables (PIE), stack canaries, No-Execute (NX), Relocation Read-Only (RELRO), and FORTIFY_SOURCE provide critical defense-in-depth against memory corruption vulnerabilities. The absence of these protections reduces the complexity of exploiting vulnerabilities in the firmware and may reveal details about the binary's security posture, enabling attackers to tailor exploitation strategies more effectively.
+Compiled binaries within IoT firmware may lack standard exploit mitigation features that are enabled through compiler and linker security flags. Security hardening features such as Position Independent Executables (PIE), stack canaries, No-Execute (NX), Relocation Read-Only (RELRO), and FORTIFY_SOURCE provide critical defense-in-depth against memory corruption vulnerabilities. Research into IoT router firmware has found that a significant proportion of embedded binaries lack key mitigations such as stack canaries and full RELRO, leaving devices vulnerable to memory corruption exploitation. The absence of these protections reduces the complexity of exploiting vulnerabilities in the firmware — for example, an attacker can use Return-Oriented Programming (ROP) techniques against binaries that lack PIE/ASLR, and may inject shellcode into binaries that lack NX protection — and reveals details about the binary's security posture that enable more targeted exploitation strategies. Real-world impact is demonstrated by vulnerabilities such as CVE-2022-48174, a stack buffer overflow in BusyBox affecting millions of embedded and IoT devices, where missing stack canaries and ASLR significantly lowered the exploitation barrier.
 
 **Test Objectives**
 
@@ -228,11 +228,11 @@ Firmware build processes should enable security hardening features at the compil
 
 - Enable full RELRO by linking with `-z relro -z now`
 
-- Enable FORTIFY_SOURCE by compiling with `-D_FORTIFY_SOURCE=2 -O1`
+- Enable FORTIFY_SOURCE by compiling with `-D_FORTIFY_SOURCE=2 -O1` (minimum optimization level required; `-D_FORTIFY_SOURCE=3` is available in newer toolchains such as GCC 12+ for broader coverage)
 
-- NX is enabled by default in most modern toolchains; verify it is not explicitly disabled
+- NX is enabled by default in most modern toolchains; verify it is not explicitly disabled with `-z execstack`
 
-Build system configurations should be audited to ensure hardening flags are applied consistently across all compiled components, including third-party libraries included in the firmware.
+Build system configurations should be audited to ensure hardening flags are applied consistently across all compiled components, including third-party libraries included in the firmware. On cross-compiled firmware for ARM, MIPS, or ARM64 targets, all five mitigations are supported; however, toolchain defaults may differ from those of desktop platforms and should be explicitly verified.
 
 **References**
 
@@ -241,6 +241,13 @@ For this test case, data from the following sources was consolidated:
 * OWASP ["Firmware Security Testing Methodology"][owasp_fstm]
 * ["IoT Penetration Testing Cookbook"][iot_penetration_testing_cookbook] by Aaron Guzman and Aditya Gupta
 * ["Practical IoT Hacking"][practical_iot_hacking] by Fotios Chantzis, Ioannis Stais, Paulino Calderon, Evangelos Deirmentzoglou, and Beau Woods
+* [ETSI EN 303 645][etsi_en_303_645] - Cybersecurity for Consumer Internet of Things: Baseline Requirements
+* [NIST SP 800-213][nist_sp_800_213] - IoT Device Cybersecurity Guidance for the Federal Government
+* IEC 62443-4-2 - Security for Industrial Automation and Control Systems: Technical Security Requirements for IACS Components
+* [OpenSSF Compiler Options Hardening Guide for C and C++][openssf_compiler_hardening]
+* [CWE-119][cwe_119]: Improper Restriction of Operations within the Bounds of a Memory Buffer
+* [CWE-121][cwe_121]: Stack-based Buffer Overflow
+* [CWE-693][cwe_693]: Protection Mechanism Failure
 
 
 
@@ -514,3 +521,9 @@ For this test case, data from the following sources was consolidated:
 [iot_penetration_testing_cookbook]: https://www.packtpub.com/product/iot-penetration-testing-cookbook/9781787280571	"IoT Penetration Testing Cookbook"
 [iot_hackers_handbook]: https://link.springer.com/book/10.1007/978-1-4842-4300-8	"The IoT Hacker's Handbook"
 [practical_iot_hacking]: https://nostarch.com/practical-iot-hacking	"Practical IoT Hacking"
+[etsi_en_303_645]: https://www.etsi.org/deliver/etsi_en/303600_303699/303645/02.01.00_30/en_303645v020100v.pdf	"ETSI EN 303 645 - Cybersecurity for Consumer IoT"
+[nist_sp_800_213]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-213.pdf	"NIST SP 800-213 - IoT Device Cybersecurity Guidance"
+[openssf_compiler_hardening]: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html	"OpenSSF Compiler Options Hardening Guide for C and C++"
+[cwe_119]: https://cwe.mitre.org/data/definitions/119.html	"CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer"
+[cwe_121]: https://cwe.mitre.org/data/definitions/121.html	"CWE-121: Stack-based Buffer Overflow"
+[cwe_693]: https://cwe.mitre.org/data/definitions/693.html	"CWE-693: Protection Mechanism Failure"

--- a/src/03_test_cases/firmware/README.md
+++ b/src/03_test_cases/firmware/README.md
@@ -6,6 +6,7 @@
   * [Disclosure of Source Code and Binaries (ISTG-FW-INFO-001)](#disclosure-of-source-code-and-binaries-istg-fw-info-001)
   * [Disclosure of Implementation Details (ISTG-FW-INFO-002)](#disclosure-of-implementation-details-istg-fw-info-002)
   * [Disclosure of Ecosystem Details (ISTG-FW-INFO-003)](#disclosure-of-ecosystem-details-istg-fw-info-003)
+  * [Insecure Binary Compilation Options (ISTG-FW-INFO-004)](#insecure-binary-compilation-options-istg-fw-info-004)
 * [Configuration and Patch Management (ISTG-FW-CONF)](#configuration-and-patch-management-istg-fw-conf)
   * [Usage of Outdated Software (ISTG-FW-CONF-001)](#usage-of-outdated-software-istg-fw-conf-001)
   * [Presence of Unnecessary Software and Functionalities (ISTG-FW-CONF-002)](#presence-of-unnecessary-software-and-functionalities-istg-fw-conf-002)
@@ -176,6 +177,70 @@ For this test case, data from the following available sources was consolidated:
 * ["The IoT Hacker's Handbook"][iot_hackers_handbook] by Aditya Gupta
 * ["Practical IoT Hacking"][practical_iot_hacking] by Fotios Chantzis, Ioannis Stais, Paulino Calderon, Evangelos Deirmentzoglou, and Beau Woods
 * Key aspects of testing of the T-Systems Multimedia Solutions GmbH
+
+
+
+### Insecure Binary Compilation Options (ISTG-FW-INFO-004)
+
+**Required Access Levels**
+
+<table width="100%">
+	<tr valign="top">
+		<th width="1%" align="left">Physical</th>
+ <td><i>PA-1</i> - <i>PA-4</i><br>(depending on how the firmware can be accessed, e.g., via an internal/physical debugging interface or remotely via SSH)</td>
+	</tr>
+	<tr valign="top">
+		<th align="left">Authorization</th>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device) </td>
+	</tr>
+</table>
+
+**Summary**
+
+Compiled binaries within IoT firmware may lack standard exploit mitigation features that are enabled through compiler and linker security flags. Security hardening features such as Position Independent Executables (PIE), stack canaries, No-Execute (NX), Relocation Read-Only (RELRO), and FORTIFY_SOURCE provide critical defense-in-depth against memory corruption vulnerabilities. The absence of these protections reduces the complexity of exploiting vulnerabilities in the firmware and may reveal details about the binary's security posture, enabling attackers to tailor exploitation strategies more effectively.
+
+**Test Objectives**
+
+- Compiled binaries within the firmware must be identified and analyzed for the presence or absence of common exploit mitigation features, including:
+  - **PIE (Position Independent Executable):** enables ASLR at the binary level, randomizing load addresses and complicating return-oriented programming (ROP) attacks
+
+  - **NX/W^X (No-Execute):** prevents execution of code injected into writable memory regions such as the stack or heap
+
+  - **Stack canaries (Stack Smashing Protector, SSP):** detect stack-based buffer overflows prior to function return
+
+  - **RELRO (Relocation Read-Only):** hardens the Global Offset Table (GOT) against overwrite attacks by marking it read-only after dynamic linking
+
+  - **FORTIFY_SOURCE:** replaces unsafe C standard library functions with bounds-checked variants at compile time
+
+- Tools such as `checksec`, `readelf`, `objdump`, and `rabin2` should be used to assess binary hardening properties.
+
+- Identified missing mitigations must be documented and assessed in the context of the binary's role and potential exploitability.
+
+- Results should be used to inform further binary analysis and exploitation testing (also see [ISTG-FW-INFO-001](#disclosure-of-source-code-and-binaries-istg-fw-info-001)).
+
+**Remediation**
+
+Firmware build processes should enable security hardening features at the compiler and linker level:
+
+- Enable PIE by compiling with `-fPIE` and linking with `-pie`
+
+- Enable stack canaries by compiling with `-fstack-protector-strong`
+
+- Enable full RELRO by linking with `-z relro -z now`
+
+- Enable FORTIFY_SOURCE by compiling with `-D_FORTIFY_SOURCE=2 -O1`
+
+- NX is enabled by default in most modern toolchains; verify it is not explicitly disabled
+
+Build system configurations should be audited to ensure hardening flags are applied consistently across all compiled components, including third-party libraries included in the firmware.
+
+**References**
+
+For this test case, data from the following sources was consolidated:
+
+* OWASP ["Firmware Security Testing Methodology"][owasp_fstm]
+* ["IoT Penetration Testing Cookbook"][iot_penetration_testing_cookbook] by Aaron Guzman and Aditya Gupta
+* ["Practical IoT Hacking"][practical_iot_hacking] by Fotios Chantzis, Ioannis Stais, Paulino Calderon, Evangelos Deirmentzoglou, and Beau Woods
 
 
 

--- a/src/03_test_cases/firmware/README.md
+++ b/src/03_test_cases/firmware/README.md
@@ -220,19 +220,7 @@ Compiled binaries within IoT firmware may lack standard exploit mitigation featu
 
 **Remediation**
 
-Firmware build processes should enable security hardening features at the compiler and linker level:
-
-- Enable PIE by compiling with `-fPIE` and linking with `-pie`
-
-- Enable stack canaries by compiling with `-fstack-protector-strong`
-
-- Enable full RELRO by linking with `-z relro -z now`
-
-- Enable FORTIFY_SOURCE by compiling with `-D_FORTIFY_SOURCE=2 -O1` (minimum optimization level required; `-D_FORTIFY_SOURCE=3` is available in newer toolchains such as GCC 12+ for broader coverage)
-
-- NX is enabled by default in most modern toolchains; verify it is not explicitly disabled with `-z execstack`
-
-Build system configurations should be audited to ensure hardening flags are applied consistently across all compiled components, including third-party libraries included in the firmware. On cross-compiled firmware for ARM, MIPS, or ARM64 targets, all five mitigations are supported; however, toolchain defaults may differ from those of desktop platforms and should be explicitly verified.
+The firmware build process should enable the exploit mitigations supported by the toolchain — PIE, stack canaries, full RELRO, and FORTIFY_SOURCE — and apply them consistently across all compiled components, including bundled third-party libraries. Note that toolchain defaults for cross-compiled targets may differ from those of desktop platforms and should be verified explicitly rather than assumed.
 
 **References**
 
@@ -241,9 +229,6 @@ For this test case, data from the following sources was consolidated:
 * OWASP ["Firmware Security Testing Methodology"][owasp_fstm]
 * ["IoT Penetration Testing Cookbook"][iot_penetration_testing_cookbook] by Aaron Guzman and Aditya Gupta
 * ["Practical IoT Hacking"][practical_iot_hacking] by Fotios Chantzis, Ioannis Stais, Paulino Calderon, Evangelos Deirmentzoglou, and Beau Woods
-* [ETSI EN 303 645][etsi_en_303_645] - Cybersecurity for Consumer Internet of Things: Baseline Requirements
-* [NIST SP 800-213][nist_sp_800_213] - IoT Device Cybersecurity Guidance for the Federal Government
-* IEC 62443-4-2 - Security for Industrial Automation and Control Systems: Technical Security Requirements for IACS Components
 * [OpenSSF Compiler Options Hardening Guide for C and C++][openssf_compiler_hardening]
 * [CWE-119][cwe_119]: Improper Restriction of Operations within the Bounds of a Memory Buffer
 * [CWE-121][cwe_121]: Stack-based Buffer Overflow
@@ -521,8 +506,6 @@ For this test case, data from the following sources was consolidated:
 [iot_penetration_testing_cookbook]: https://www.packtpub.com/product/iot-penetration-testing-cookbook/9781787280571	"IoT Penetration Testing Cookbook"
 [iot_hackers_handbook]: https://link.springer.com/book/10.1007/978-1-4842-4300-8	"The IoT Hacker's Handbook"
 [practical_iot_hacking]: https://nostarch.com/practical-iot-hacking	"Practical IoT Hacking"
-[etsi_en_303_645]: https://www.etsi.org/deliver/etsi_en/303600_303699/303645/02.01.00_30/en_303645v020100v.pdf	"ETSI EN 303 645 - Cybersecurity for Consumer IoT"
-[nist_sp_800_213]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-213.pdf	"NIST SP 800-213 - IoT Device Cybersecurity Guidance"
 [openssf_compiler_hardening]: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html	"OpenSSF Compiler Options Hardening Guide for C and C++"
 [cwe_119]: https://cwe.mitre.org/data/definitions/119.html	"CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer"
 [cwe_121]: https://cwe.mitre.org/data/definitions/121.html	"CWE-121: Stack-based Buffer Overflow"

--- a/src/03_test_cases/memory/README.md
+++ b/src/03_test_cases/memory/README.md
@@ -209,7 +209,7 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 
 **Summary**
 
-Binaries recovered from device memory may lack standard exploit mitigation features enabled through compiler and linker security flags. When binaries are extracted directly from memory chips, their compilation security properties can be assessed to understand the device's exploitability posture. The absence of protections such as PIE, stack canaries, NX, RELRO, and FORTIFY_SOURCE reduces the complexity of developing exploits for identified vulnerabilities in the extracted binaries.
+Binaries recovered from device memory may lack standard exploit mitigation features enabled through compiler and linker security flags. When binaries are extracted directly from memory chips, their compilation security properties can be assessed to understand the device's exploitability posture. The absence of protections such as PIE, stack canaries, NX, RELRO, and FORTIFY_SOURCE reduces the complexity of developing exploits for identified vulnerabilities in the extracted binaries, enabling techniques such as Return-Oriented Programming (ROP) or direct shellcode injection. Real-world impact is demonstrated by vulnerabilities such as CVE-2022-48174, a stack buffer overflow in BusyBox affecting millions of embedded and IoT devices, where missing stack canaries and ASLR significantly lowered the exploitation barrier.
 
 **Test Objectives**
 
@@ -239,6 +239,12 @@ For this test case, data from the following sources was consolidated:
 * ["IoT Pentesting Guide"][iot_pentesting_guide] by Aditya Gupta
 * ["IoT Penetration Testing Cookbook"][iot_penetration_testing_cookbook] by Aaron Guzman and Aditya Gupta
 * ["The IoT Hacker's Handbook"][iot_hackers_handbook] by Aditya Gupta
+* [ETSI EN 303 645][etsi_en_303_645] - Cybersecurity for Consumer Internet of Things: Baseline Requirements
+* [NIST SP 800-213][nist_sp_800_213] - IoT Device Cybersecurity Guidance for the Federal Government
+* [OpenSSF Compiler Options Hardening Guide for C and C++][openssf_compiler_hardening]
+* [CWE-119][cwe_119]: Improper Restriction of Operations within the Bounds of a Memory Buffer
+* [CWE-121][cwe_121]: Stack-based Buffer Overflow
+* [CWE-693][cwe_693]: Protection Mechanism Failure
 
 This test case is based on: [ISTG-FW-INFO-004](../firmware/README.md#insecure-binary-compilation-options-istg-fw-info-004).
 
@@ -335,3 +341,9 @@ This test case is based on: [ISTG-FW-CRYPT-001](../firmware/README.md#usage-of-w
 [iot_pentesting_guide]: https://www.iotpentestingguide.com	"IoT Pentesting Guide"
 [iot_penetration_testing_cookbook]: https://www.packtpub.com/product/iot-penetration-testing-cookbook/9781787280571	"IoT Penetration Testing Cookbook"
 [iot_hackers_handbook]: https://link.springer.com/book/10.1007/978-1-4842-4300-8	"The IoT Hacker's Handbook"
+[etsi_en_303_645]: https://www.etsi.org/deliver/etsi_en/303600_303699/303645/02.01.00_30/en_303645v020100v.pdf	"ETSI EN 303 645 - Cybersecurity for Consumer IoT"
+[nist_sp_800_213]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-213.pdf	"NIST SP 800-213 - IoT Device Cybersecurity Guidance"
+[openssf_compiler_hardening]: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html	"OpenSSF Compiler Options Hardening Guide for C and C++"
+[cwe_119]: https://cwe.mitre.org/data/definitions/119.html	"CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer"
+[cwe_121]: https://cwe.mitre.org/data/definitions/121.html	"CWE-121: Stack-based Buffer Overflow"
+[cwe_693]: https://cwe.mitre.org/data/definitions/693.html	"CWE-693: Protection Mechanism Failure"

--- a/src/03_test_cases/memory/README.md
+++ b/src/03_test_cases/memory/README.md
@@ -7,6 +7,7 @@
   * [Disclosure of Implementation Details (ISTG-MEM-INFO-002)](#disclosure-of-implementation-details-istg-mem-info-002)
   * [Disclosure of Ecosystem Details (ISTG-MEM-INFO-003)](#disclosure-of-ecosystem-details-istg-mem-info-003)
   * [Disclosure of User Data (ISTG-MEM-INFO-004)](#disclosure-of-user-data-istg-mem-info-004)
+  * [Insecure Binary Compilation Options (ISTG-MEM-INFO-005)](#insecure-binary-compilation-options-istg-mem-info-005)
 * [Secrets (ISTG-MEM-SCRT)](#secrets-istg-mem-scrt)
   * [Unencrypted Storage of Secrets (ISTG-MEM-SCRT-001)](#unencrypted-storage-of-secrets-istg-mem-scrt-001)
 * [Cryptography (ISTG-MEM-CRYPT)](#cryptography-istg-mem-crypt)
@@ -190,6 +191,56 @@ For this test case, data from the following sources was consolidated:
 * ["The IoT Hacker's Handbook"][iot_hackers_handbook] by Aditya Gupta
 
 This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmware.md#disclosure-of-user-data-istg-fw[inst]-info-001).
+
+
+
+### Insecure Binary Compilation Options (ISTG-MEM-INFO-005)
+**Required Access Levels**
+
+<table width="100%">
+	<tr valign="top">
+		<th width="1%" align="left">Physical</th>
+ <td><i>PA-4</i></td>
+	</tr>
+	<tr valign="top">
+		<th align="left">Authorization</th>
+		<td><i>AA-1</i></tr>
+</table>
+
+**Summary**
+
+Binaries recovered from device memory may lack standard exploit mitigation features enabled through compiler and linker security flags. When binaries are extracted directly from memory chips, their compilation security properties can be assessed to understand the device's exploitability posture. The absence of protections such as PIE, stack canaries, NX, RELRO, and FORTIFY_SOURCE reduces the complexity of developing exploits for identified vulnerabilities in the extracted binaries.
+
+**Test Objectives**
+
+- Binaries identified within the device memory must be analyzed for the presence or absence of common exploit mitigation features, including:
+  - **PIE (Position Independent Executable):** enables ASLR at the binary level, randomizing load addresses and complicating return-oriented programming (ROP) attacks
+
+  - **NX/W^X (No-Execute):** prevents execution of code injected into writable memory regions such as the stack or heap
+
+  - **Stack canaries (Stack Smashing Protector, SSP):** detect stack-based buffer overflows prior to function return
+
+  - **RELRO (Relocation Read-Only):** hardens the Global Offset Table (GOT) against overwrite attacks by marking it read-only after dynamic linking
+
+  - **FORTIFY_SOURCE:** replaces unsafe C standard library functions with bounds-checked variants at compile time
+
+- Tools such as `checksec`, `readelf`, `objdump`, and `rabin2` should be used to assess binary hardening properties.
+
+- Identified missing mitigations must be documented and assessed in the context of the binary's role and potential exploitability.
+
+**Remediation**
+
+Firmware build processes should enable security hardening features at the compiler and linker level. See [ISTG-FW-INFO-004](../firmware/README.md#insecure-binary-compilation-options-istg-fw-info-004) for detailed remediation guidance.
+
+**References**
+
+For this test case, data from the following sources was consolidated:
+
+* ["IoT Pentesting Guide"][iot_pentesting_guide] by Aditya Gupta
+* ["IoT Penetration Testing Cookbook"][iot_penetration_testing_cookbook] by Aaron Guzman and Aditya Gupta
+* ["The IoT Hacker's Handbook"][iot_hackers_handbook] by Aditya Gupta
+
+This test case is based on: [ISTG-FW-INFO-004](../firmware/README.md#insecure-binary-compilation-options-istg-fw-info-004).
 
 
 

--- a/src/03_test_cases/memory/README.md
+++ b/src/03_test_cases/memory/README.md
@@ -239,8 +239,6 @@ For this test case, data from the following sources was consolidated:
 * ["IoT Pentesting Guide"][iot_pentesting_guide] by Aditya Gupta
 * ["IoT Penetration Testing Cookbook"][iot_penetration_testing_cookbook] by Aaron Guzman and Aditya Gupta
 * ["The IoT Hacker's Handbook"][iot_hackers_handbook] by Aditya Gupta
-* [ETSI EN 303 645][etsi_en_303_645] - Cybersecurity for Consumer Internet of Things: Baseline Requirements
-* [NIST SP 800-213][nist_sp_800_213] - IoT Device Cybersecurity Guidance for the Federal Government
 * [OpenSSF Compiler Options Hardening Guide for C and C++][openssf_compiler_hardening]
 * [CWE-119][cwe_119]: Improper Restriction of Operations within the Bounds of a Memory Buffer
 * [CWE-121][cwe_121]: Stack-based Buffer Overflow
@@ -341,8 +339,6 @@ This test case is based on: [ISTG-FW-CRYPT-001](../firmware/README.md#usage-of-w
 [iot_pentesting_guide]: https://www.iotpentestingguide.com	"IoT Pentesting Guide"
 [iot_penetration_testing_cookbook]: https://www.packtpub.com/product/iot-penetration-testing-cookbook/9781787280571	"IoT Penetration Testing Cookbook"
 [iot_hackers_handbook]: https://link.springer.com/book/10.1007/978-1-4842-4300-8	"The IoT Hacker's Handbook"
-[etsi_en_303_645]: https://www.etsi.org/deliver/etsi_en/303600_303699/303645/02.01.00_30/en_303645v020100v.pdf	"ETSI EN 303 645 - Cybersecurity for Consumer IoT"
-[nist_sp_800_213]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-213.pdf	"NIST SP 800-213 - IoT Device Cybersecurity Guidance"
 [openssf_compiler_hardening]: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html	"OpenSSF Compiler Options Hardening Guide for C and C++"
 [cwe_119]: https://cwe.mitre.org/data/definitions/119.html	"CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer"
 [cwe_121]: https://cwe.mitre.org/data/definitions/121.html	"CWE-121: Stack-based Buffer Overflow"


### PR DESCRIPTION
Closes #8

## Summary

Adds two new test cases addressing analysis of compiled binary security flags in IoT firmware and memory components, as requested in issue #8.

**ISTG-FW-INFO-004 — Insecure Binary Compilation Options** (`src/03_test_cases/firmware/README.md`)
Covers analysis of firmware binaries for the presence or absence of:
- PIE (Position Independent Executable / ASLR)
- NX / W^X (No-Execute)
- Stack canaries (SSP / Stack Smashing Protector)
- RELRO (Relocation Read-Only)
- FORTIFY_SOURCE

**ISTG-MEM-INFO-005 — Insecure Binary Compilation Options** (`src/03_test_cases/memory/README.md`)
Mirror test case for binaries extracted directly from device memory chips (PA-4), cross-referenced to ISTG-FW-INFO-004 for remediation guidance.

Both entries are linked from their respective Table of Contents sections. The `checklists/checklist.md` has been regenerated via `scripts/create_checklists.py` to include the new IDs.

## Tools referenced
- `checksec`
- `readelf`
- `objdump`
- `rabin2` (Radare2)

## Test plan
- [ ] Review test case content for accuracy and consistency with guide style
- [ ] Verify checklist entries appear correctly at the expected positions
- [ ] Confirm mdBook builds cleanly with the new sections