### PR TITLE
Fix cross-platform failures in build and checklist tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# mdBook build output
+book/
+
+# Files copied into src/ by scripts/mdbook_prepare.sh and removed again by
+# scripts/mdbook_cleanup.sh; they should never be committed from src/
+src/README.md
+src/LICENSE.md
+src/acknowledgements.md
+
+# sed backup files
+*.bak
+
+# macOS
+.DS_Store
+._*

--- a/scripts/create_checklists.py
+++ b/scripts/create_checklists.py
@@ -56,8 +56,12 @@ def parse_test_cases(test_case_dir=TEST_CASE_DIR):
             if component_id is not None:
 
                 # parse other files in the component directory
-                # every file besides "README.md" resembles a component specialization
+                # every markdown file besides "README.md" resembles a component specialization
+                # hidden files are skipped (e.g., macOS "._*" AppleDouble files, which are binary)
                 for filename in filenames:
+
+                    if filename.startswith(".") or not filename.endswith(".md"):
+                        continue
 
                     test_cases_component_specialization = parse_file(join(dirpath, filename))
 

--- a/scripts/mdbook_cleanup.sh
+++ b/scripts/mdbook_cleanup.sh
@@ -2,5 +2,9 @@ rm ./src/README.md
 rm ./src/LICENSE.md
 rm ./src/acknowledgements.md
 
-find ./book/ -type f -name "*.html" -exec sed -i "s/README.html/index.html/g" {} +
-sed -i "s/\/src\//\//g" ./book/index.html
+# "-i.bak" is portable across GNU sed (Linux/CI) and BSD sed (macOS); a bare
+# "-i" consumes the next argument as the backup suffix on BSD. LC_ALL=C stops
+# BSD sed rejecting the generated HTML as an "illegal byte sequence".
+find ./book/ -type f -name "*.html" ! -name "._*" -exec env LC_ALL=C sed -i.bak "s/README.html/index.html/g" {} +
+LC_ALL=C sed -i.bak "s/\/src\//\//g" ./book/index.html
+find ./book/ -type f -name "*.bak" ! -name "._*" -delete

--- a/scripts/mdbook_prepare.sh
+++ b/scripts/mdbook_prepare.sh
@@ -1,5 +1,8 @@
 cp ./README.md ./src/
-sed -i -e 's/src\/img/img/g' ./src/README.md
+# "-i.bak" is portable across GNU sed (Linux/CI) and BSD sed (macOS); a bare
+# "-i" consumes the next argument as the backup suffix on BSD.
+LC_ALL=C sed -i.bak -e 's/src\/img/img/g' ./src/README.md
+rm -f ./src/README.md.bak
 
 cp ./LICENSE.md ./src/
 cp ./acknowledgements.md ./src/


### PR DESCRIPTION
## Summary

Two independent tooling problems, both found while verifying that the local build steps documented for contributors actually work.

## 1. The mdBook wrapper scripts depended on GNU sed

`scripts/mdbook_prepare.sh` and `scripts/mdbook_cleanup.sh` used a bare `sed -i`. GNU sed reads the following argument as the next option; BSD sed reads it as the backup suffix. On a BSD userland the book still built, but the pre- and post-processing around it did not:

- `mdbook_prepare.sh` applied its substitution and then left a stray `src/README.md-e` backup behind in the source tree.
- **Both** `mdbook_cleanup.sh` substitutions failed outright, so the built HTML kept its `README.html` links and the `/src/` path rewrite never happened. This failed loudly on stderr but the script still exited 0.

Fixes:
- Switched to the portable `-i.bak` form, removing the backups afterwards.
- Forced `LC_ALL=C`, since BSD sed otherwise rejects the generated HTML as an `illegal byte sequence`.
- Excluded `._*` from the `find`, so AppleDouble shadows on non-native filesystems don't break the delete step.

## 2. The checklist generator aborted on any stray file

`scripts/create_checklists.py` parsed **every** file it found in a component directory, so a single non-markdown file aborted checklist generation with a `UnicodeDecodeError`.

**This is not platform-specific.** Any stray file in `src/03_test_cases/<component>/` breaks generation, including in CI — which means a single accidentally-committed stray file would break the `Create checklists` workflow on `main`. It now skips hidden and non-markdown files.

Iteration order is deliberately **left unchanged**. Sorting alphabetically would be more deterministic, but would order specializations in the checklist differently from the guide once further `ISTG-INT` specializations land — alphabetical gives I2C, JTAG, SPI, UART while document order will be I2C 3.5.1, UART 3.5.2, JTAG 3.5.3, SPI 3.5.4. Worth fixing separately by ordering on the section number rather than the filename; I'll open an issue.

## 3. Added a `.gitignore`

The repository had none. The mdBook output directory, the three files copied into `src/` during a build, and sed backups were all untracked but not ignored, so they could be committed by accident. Confirmed all three `src/` entries are genuinely untracked, so nothing tracked is being shadowed.

## Verification

- `./scripts/mdbook_prepare.sh && mdbook build && ./scripts/mdbook_cleanup.sh` completes cleanly, both substitutions verified applied (14 rewritten links, 0 stale `README.html` refs), no stray artifacts left behind.
- `python3 scripts/create_checklists.py` runs to completion; **`checklist.md` is byte-identical** and **`checklist.xlsx` is cell-for-cell identical** (100 rows compared via openpyxl) to the committed output.

Note: `checklist.xlsx` differs by two metadata bytes on every regeneration regardless of content. That's pre-existing and explains why the automated `Update checklists` commits show a binary delta with no content change — e.g. d813469 showing `Bin 9178 -> 9175`.

## Test plan

- [ ] Confirm the `Create checklists` workflow still produces identical `checklist.md` on merge
- [ ] Confirm the GitHub Pages deploy is unaffected
