### PR TITLE
Stop the checklist workflow cancelling the Pages deployment, and update actions to Node 24

### DIFF
--- a/.github/workflows/create-checklists.yml
+++ b/.github/workflows/create-checklists.yml
@@ -28,9 +28,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
       run: |
         python3 scripts/create_checklists.py
     - name: Commit and push
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@v10
       with:
         message: Update checklists
         add: "checklists/*"

--- a/.github/workflows/create-checklists.yml
+++ b/.github/workflows/create-checklists.yml
@@ -12,10 +12,16 @@ on:
 permissions:
   contents: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Serialise runs of THIS workflow only, so two runs cannot race on the push
+# below. This must not share a group with the Pages deployment: a concurrency
+# group holds at most one running plus one pending run, and a newly queued run
+# evicts the pending one regardless of cancel-in-progress, so sharing a group
+# meant a burst of merges could cancel the site deployment entirely.
+#
+# Losing an intermediate run here is harmless, because the generator rebuilds
+# the checklists from the current source rather than amending previous output.
 concurrency:
-  group: "pages"
+  group: "create-checklists"
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.40
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
@@ -44,9 +44,9 @@ jobs:
         run: bash ./scripts/mdbook_cleanup.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./book
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,7 +1,10 @@
 name: Deploy mdBook to GH Pages
 
 on:
-  # Runs on pushes targeting the main branch, only if files in the src directory were changed
+  # Runs on every push targeting the main branch. Deliberately not filtered by
+  # path: the book is built from src/ plus the root README, LICENSE and
+  # acknowledgements files, book.toml and the mdbook scripts, so a filter narrow
+  # enough to be useful would risk silently skipping a needed deployment.
   push:
     branches: ["main"]
 


### PR DESCRIPTION
Two CI fixes, as separate commits so the version bumps stay independently revertable.

## 1. The checklist workflow was cancelling the Pages deployment

Merging #35, #36, #31 and #23 in quick succession cancelled the `Deploy mdBook to GH Pages` run on **every one of the four commits, including the last**. The published guide silently stayed on the previous content, with no failed check anywhere to signal it. I had to dispatch the deploy manually to bring the site current.

Both workflows declared `concurrency: group: "pages"`. A concurrency group holds at most **one running plus one pending** run, and a newly queued run evicts the pending one *regardless of `cancel-in-progress`* — that setting only protects a run that has already started ([docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency), [discussion #41518](https://github.com/orgs/community/discussions/41518)). So each merge queued a checklist run and a deploy run into the same group, and each subsequent merge evicted whichever was still pending. The deploy is the longer job, so it lost every time.

The checklist workflow deploys nothing — its concurrency block was copied verbatim from the Pages workflow, comment included, still referring to "concurrent deployment" and "production deployments". It now has its own group. Serialisation is still wanted within that workflow so two runs can't race on the commit and push, but losing an intermediate run is harmless because the generator rebuilds the checklists from current source rather than amending previous output.

**Also corrected the Pages trigger comment**, which claimed the workflow runs "only if files in the src directory were changed". There is no path filter, and I deliberately did not add one: the book builds from `src/` plus the root `README.md`, `LICENSE.md` and `acknowledgements.md`, `book.toml` and the mdbook scripts, so a filter narrow enough to be worth having would risk silently skipping a needed deployment — the exact failure this PR fixes.

Worth knowing: the automatic `Update checklists` commit cannot recover a missed deployment either, because it is pushed with `GITHUB_TOKEN` and GitHub does not trigger workflows from those pushes. Harmless for the site, since `checklists/` is not part of the built book, but nothing retries a lost deploy.

## 2. Node 24 action versions

Node 20 actions are already being force-run on Node 24, which produced the deprecation annotation on the last deployment. #21/#22 covered the Scorecard workflow but not these two files, and the checklist workflow had never been updated at all.

| Action | Was | Now |
|-|-|-|
| `actions/checkout` | v6 / v3 | v7 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/setup-python` | v3 | v6 |
| `EndBug/add-and-commit` | v9 | v10 |

`configure-pages@v6` and `deploy-pages@v5` are the releases that moved to Node 24; `upload-pages-artifact@v5` picks it up via `upload-artifact@v7`.

`setup-python` is held at **v6 rather than v7** on purpose. v6 already declares `using: node24`, so it satisfies the reason for this change, while v7 shipped ten days ago and removes the `pip-install` input. No benefit to taking a fresh major with a breaking input removal, even though this workflow doesn't use that input.

Every tag was confirmed to exist upstream before being referenced.

## Verification

YAML parses for both files, and concurrency groups are now distinct across all three workflows (`pages`, `create-checklists`, and none for Scorecard).

Neither workflow interpolates any `github.event.*` value into a `run:` step, so there is no injection surface in these changes.

Merging this won't itself exercise the fix, since workflow-file changes don't match the checklist workflow's `src/03_test_cases/**.md` filter. After merge, dispatching both workflows simultaneously should show both completing — under the old configuration one would have cancelled the other.

## Test plan

- [ ] Confirm the Pages deploy succeeds on merge
- [ ] Dispatch both workflows at once and confirm neither cancels the other
- [ ] Confirm the next `src/03_test_cases/**.md` change still regenerates checklists correctly
