### PR TITLE
docs: normalize component test case formatting

### DIFF
--- a/src/03_test_cases/internal_interfaces/README.md
+++ b/src/03_test_cases/internal_interfaces/README.md
@@ -53,6 +53,7 @@ In regards to test case categories that are relevant for an internal interface, 
 Depending on the access model for a given device, only certain individuals might be allowed to access an internal interface. Thus, proper authentication and authorization procedures need to be in place, which ensure that only authorized users can get access.
 
 ### Unauthorized Access to the Interface (ISTG-INT-AUTHZ-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -62,7 +63,8 @@ Depending on the access model for a given device, only certain individuals might
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -92,6 +94,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/README.md#unauthorized-access-to-the-data-exchange-service-istg-des-authz-001).
 
 ### Privilege Escalation (ISTG-INT-AUTHZ-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -127,6 +130,7 @@ This test case is based on: [ISTG-DES-AUTHZ-002](../data_exchange_services/READM
 Internal interfaces might disclose various information, which could reveal details regarding the inner workings of the device or the surrounding IoT ecosystem to potential attackers. This could enable and facilitate further, more advanced attacks.
 
 ### Disclosure of Implementation Details (ISTG-INT-INFO-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -172,6 +176,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-of-implementation-details-istg-fw-info-002).
 
 ### Disclosure of Ecosystem Details (ISTG-INT-INFO-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -211,6 +216,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-of-ecosystem-details-istg-fw-info-003).
 
 ### Disclosure of User Data (ISTG-INT-INFO-003)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -254,6 +260,7 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 Since IoT devices can have a long lifespan, it is important to make sure that the software, running on the device, is regularly updated in order to apply the latest security patches. The update process of the firmware itself will be covered by [ISTG-FW[UPDT]](../firmware/firmware_update_mechanism.md). However, it must also be verified that software packages, which are running on the device and listening on interfaces, are up-to-date as well.
 
 ### Usage of Outdated Software (ISTG-INT-CONF-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -297,6 +304,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-outdated-software-istg-fw-conf-001).
 
 ### Presence of Unnecessary Software and Functionalities (ISTG-INT-CONF-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -344,6 +352,7 @@ This test case is based on: [ISTG-FW-CONF-002](../firmware/README.md#presence-of
 IoT devices are often operated outside of the control space of their manufacturer. Still, they need to establish connections to other network nodes within the IoT ecosystem, e.g., to request and receive firmware updates or to send data to a cloud API. Hence, it might be required that the device has to provide some kind of authentication credential or secret. These secrets need to be stored on the device in a secure manner to prevent them from being stolen and used to impersonate the device.
 
 ### Access to Confidential Data (ISTG-INT-SCRT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -387,6 +396,7 @@ This test case is based on: [ISTG-DES-SCRT-001](../data_exchange_services/README
 Many IoT devices need to implement cryptographic algorithms, e.g., to securely store sensitive data, for authentication purposes or to receive and verify encrypted data from other network nodes. Failing to implement secure, state of the art cryptography might lead to the exposure of sensitive data, device malfunctions or loss of control over the device.
 
 ### Usage of Weak Cryptographic Algorithms (ISTG-INT-CRYPT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -436,6 +446,7 @@ This test case is based on: [ISTG-FW-CRYPT-001](../firmware/README.md#usage-of-w
 Even if all other aspects of the internal interface are securely implemented and configured, issues in the underlying logic itself might render the device vulnerable to attacks. Thus, it must be verified if the internal interface and its functionalities are working as intended and if exceptions are detected and properly handled.
 
 ### Circumvention of the Intended Business Logic (ISTG-INT-LOGIC-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -479,6 +490,7 @@ This test case is based on: [ISTG-DES-LOGIC-001](../data_exchange_services/READM
 In order to ensure that only valid and well-formed data enters the processing flows of a device, the input from a all untrustworthy sources, e.g., users or external systems, has to be verified and validated.
 
 ### Insufficient Input Validation (ISTG-INT-INPV-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -518,6 +530,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README.md#insufficient-input-validation-istg-des-inpv-001).
 
 ### Code or Command Injection (ISTG-INT-INPV-002)
+
 **Required Access Levels**
 
 <table width="100%">

--- a/src/03_test_cases/memory/README.md
+++ b/src/03_test_cases/memory/README.md
@@ -37,6 +37,7 @@ The memory of an IoT device can include various data, which, if disclosed, coul
 Tests on the device memory are performed by directly accessing the memory chips. Thus, invasive physical access (*PA-4*) is required while no user accounts are used (*AA-1*).
 
 ### Disclosure of Source Code and Binaries (ISTG-MEM-INFO-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -46,7 +47,8 @@ Tests on the device memory are performed by directly accessing the memory chips.
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -80,6 +82,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-001](../firmware/README.md#disclosure-of-source-code-and-binaries-istg-fw-info-001).
 
 ### Disclosure of Implementation Details (ISTG-MEM-INFO-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -89,7 +92,8 @@ This test case is based on: [ISTG-FW-INFO-001](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -121,6 +125,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-of-implementation-details-istg-fw-info-002).
 
 ### Disclosure of Ecosystem Details (ISTG-MEM-INFO-003)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -130,7 +135,8 @@ This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -158,6 +164,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-of-ecosystem-details-istg-fw-info-003).
 
 ### Disclosure of User Data (ISTG-MEM-INFO-004)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -167,7 +174,8 @@ This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -195,6 +203,7 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 
 
 ### Insecure Binary Compilation Options (ISTG-MEM-INFO-005)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -204,7 +213,8 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -253,6 +263,7 @@ This test case is based on: [ISTG-FW-INFO-004](../firmware/README.md#insecure-bi
 IoT devices are often operated outside of the control space of their manufacturer. Still, they need to establish connections to other network nodes within the IoT ecosystem, e.g., to request and receive firmware updates or to send data to a cloud API. Hence, it might be required that the device can provide some kind of authentication credential or secret. These secrets need to be stored on the device in a secure manner to prevent them from being stolen and used to impersonate the device.
 
 ### Unencrypted Storage of Secrets (ISTG-MEM-SCRT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -262,7 +273,8 @@ IoT devices are often operated outside of the control space of their manufactur
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -295,6 +307,7 @@ This test case is based on: [ISTG-FW-SCRT-002](../firmware/README.md#unencrypted
 Many IoT devices need to implement cryptographic algorithms, e.g., to securely store sensitive data, for authentication purposes or to receive and verify encrypted data from other network nodes. Failing to implement secure, state of the art cryptography might lead to the exposure of sensitive data, device malfunctions or loss of control over the device.
 
 ### Usage of Weak Cryptographic Algorithms (ISTG-MEM-CRYPT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -304,7 +317,8 @@ Many IoT devices need to implement cryptographic algorithms, e.g., to securely 
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**

--- a/src/03_test_cases/physical_interfaces/README.md
+++ b/src/03_test_cases/physical_interfaces/README.md
@@ -54,6 +54,7 @@ In regards of test case categories that are relevant for a physical interface, t
 Depending on the access model for a given device, only certain individuals might be allowed to access a physical interface. Thus, proper authentication and authorization procedures need to be in place, which ensure that only authorized users can get access.
 
 ### Unauthorized Access to the Interface (ISTG-PHY-AUTHZ-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -63,7 +64,8 @@ Depending on the access model for a given device, only certain individuals might
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 
@@ -91,6 +93,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/README.md#unauthorized-access-to-the-data-exchange-service-istg-des-authz-001).
 
 ### Privilege Escalation (ISTG-PHY-AUTHZ-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -131,6 +134,7 @@ This test case is based on: [ISTG-DES-AUTHZ-002](../data_exchange_services/READM
 Physical interfaces might disclose various information, which could reveal details regarding the inner workings of the device or the surrounding IoT ecosystem to potential attackers. This could enable and facilitate further, more advanced attacks.
 
 ### Disclosure of Implementation Details (ISTG-PHY-INFO-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -173,6 +177,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-of-implementation-details-istg-fw-info-002).
 
 ### Disclosure of Ecosystem Details (ISTG-PHY-INFO-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -209,6 +214,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-of-ecosystem-details-istg-fw-info-003).
 
 ### Disclosure of User Data (ISTG-PHY-INFO-003)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -249,6 +255,7 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 Since IoT devices can have a long lifespan, it is important to make sure that the software, running on the device, is regularly updated in order to apply the latest security patches. The update process of the firmware itself will be covered by [ISTG-FW[UPDT]](../firmware/firmware_update_mechanism.md). However, it must also be verified that software packages, which are running on the device and listening on interfaces, are up-to-date as well.
 
 ### Usage of Outdated Software (ISTG-PHY-CONF-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -289,6 +296,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-outdated-software-istg-fw-conf-001).
 
 ### Presence of Unnecessary Software and Functionalities (ISTG-PHY-CONF-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -333,6 +341,7 @@ This test case is based on: [ISTG-FW-CONF-002](../firmware/README.md#presence-of
 IoT devices are often operated outside of the control space of their manufacturer. Still, they need to establish connections to other network nodes within the IoT ecosystem, e.g., to request and receive firmware updates or to send data to a cloud API. Hence, it might be required that the device has to provide some kind of authentication credential or secret. These secrets need to be stored on the device in a secure manner to prevent them from being stolen and used to impersonate the device.
 
 ### Access to Confidential Data (ISTG-PHY-SCRT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -373,6 +382,7 @@ This test case is based on: [ISTG-DES-SCRT-001](../data_exchange_services/README
 Many IoT devices need to implement cryptographic algorithms, e.g., to securely store sensitive data, for authentication purposes or to receive and verify encrypted data from other network nodes. Failing to implement secure, state of the art cryptography might lead to the exposure of sensitive data, device malfunctions or loss of control over the device.
 
 ### Usage of Weak Cryptographic Algorithms (ISTG-PHY-CRYPT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -419,6 +429,7 @@ This test case is based on: [ISTG-FW-CRYPT-001](../firmware/README.md#usage-of-w
 Even if all other aspects of the physical interface are securely implemented and configured, issues in the underlying logic itself might render the device vulnerable to attacks. Thus, it must be verified if the physical interface and its functionalities are working as intended and if exceptions are detected and properly handled.
 
 ### Circumvention of the Intended Business Logic (ISTG-PHY-LOGIC-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -459,6 +470,7 @@ This test case is based on: [ISTG-DES-LOGIC-001](../data_exchange_services/READM
 In order to ensure that only valid and well-formed data enters the processing flows of a device, the input from a all untrustworthy sources, e.g., users or external systems, has to be verified and validated.
 
 ### Insufficient Input Validation (ISTG-PHY-INPV-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -495,6 +507,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README.md#insufficient-input-validation-istg-des-inpv-001).
 
 ### Code or Command Injection (ISTG-PHY-INPV-002)
+
 **Required Access Levels**
 
 <table width="100%">

--- a/src/03_test_cases/user_interfaces/README.md
+++ b/src/03_test_cases/user_interfaces/README.md
@@ -53,6 +53,7 @@ In regards to test case categories that are relevant for a user interface, the f
 Depending on the access model for a given device, only certain individuals might be allowed to access a user interface. Thus, proper authentication and authorization procedures need to be in place, which ensure that only authorized users can get access.
 
 ### Unauthorized Access to the Interface (ISTG-UI-AUTHZ-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -62,7 +63,8 @@ Depending on the access model for a given device, only certain individuals might
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -93,6 +95,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/README.md#unauthorized-access-to-the-data-exchange-service-istg-des-authz-001).
 
 ### Privilege Escalation (ISTG-UI-AUTHZ-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -137,6 +140,7 @@ This test case is based on: [ISTG-DES-AUTHZ-002](../data_exchange_services/READM
 User interface might disclose various information, which could reveal details regarding the inner workings of the device or the surrounding ISTG-ecosystem to potential attackers. This could enable and facilitate further, more advanced attacks.
 
 ### Disclosure of Implementation Details (ISTG-UI-INFO-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -183,6 +187,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-of-implementation-details-istg-fw-info-002).
 
 ### Disclosure of Ecosystem Details (ISTG-UI-INFO-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -223,6 +228,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-of-ecosystem-details-istg-fw-info-003).
 
 ### Disclosure of User Data (ISTG-UI-INFO-003)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -267,6 +273,7 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 Since ISTG-devices can have a long lifespan, it is important to make sure that the software, running on the device, is regularly updated in order to apply the latest security patches. The update process of the firmware itself will be covered by [ISTG-FW[UPDT]](../firmware/firmware_update_mechanism.md). However, it must also be verified that software packages, which are running on the device and listening on interfaces, are up-to-date as well.
 
 ### Usage of Outdated Software (ISTG-UI-CONF-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -307,6 +314,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-outdated-software-istg-fw-conf-001).
 
 ### Presence of Unnecessary Software and Functionalities (ISTG-UI-CONF-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -351,6 +359,7 @@ This test case is based on: [ISTG-FW-CONF-002](../firmware/README.md#presence-of
 ISTG-devices are often operated outside of the control space of their manufacturer. Still, they need to establish connections to other network nodes within the ISTG-ecosystem, e.g., to request and receive firmware updates or to send data to a cloud API. Hence, it might be required that the device has to provide some kind of authentication credential or secret. These secrets need to be stored on the device in a secure manner to prevent them from being stolen and used to impersonate the device.
 
 ### Access to Confidential Data (ISTG-UI-SCRT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -395,6 +404,7 @@ This test case is based on: [ISTG-DES-SCRT-001](../data_exchange_services/README
 Many ISTG-devices need to implement cryptographic algorithms, e.g., to securely store sensitive data, for authentication purposes or to receive and verify encrypted data from other network nodes. Failing to implement secure, state of the art cryptography might lead to the exposure of sensitive data, device malfunctions or loss of control over the device.
 
 ### Usage of Weak Cryptographic Algorithms (ISTG-UI-CRYPT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -441,6 +451,7 @@ This test case is based on: [ISTG-FW-CRYPT-001](../firmware/README.md#usage-of-w
 Even if all other aspects of the user interface are securely implemented and configured, issues in the underlying logic itself might render the device vulnerable to attacks. Thus, it must be verified if the user interface and its functionalities are working as intended and if exceptions are detected and properly handled.
 
 ### Circumvention of the Intended Business Logic (ISTG-UI-LOGIC-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -485,6 +496,7 @@ This test case is based on: [ISTG-DES-LOGIC-001](../data_exchange_services/READM
 In order to ensure that only valid and well-formed data enters the processing flows of a device, the input from a all untrustworthy sources, e.g., users or external systems, has to be verified and validated.
 
 ### Insufficient Input Validation (ISTG-UI-INPV-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -525,6 +537,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README.md#insufficient-input-validation-istg-des-inpv-001).
 
 ### Code or Command Injection (ISTG-UI-INPV-002)
+
 **Required Access Levels**
 
 <table width="100%">

--- a/src/03_test_cases/wireless_interfaces/README.md
+++ b/src/03_test_cases/wireless_interfaces/README.md
@@ -54,6 +54,7 @@ In regards of test case categories that are relevant for a wireless interface, t
 Depending on the access model for a given device, only certain individuals might be allowed to access a wireless interface. Thus, proper authentication and authorization procedures need to be in place, which ensure that only authorized users can get access.
 
 ### Unauthorized Access to the Interface (ISTG-WRLS-AUTHZ-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -63,7 +64,8 @@ Depending on the access model for a given device, only certain individuals might
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i></tr>
+		<td><i>AA-1</i></td>
+	</tr>
 </table>
 
 **Summary**
@@ -93,6 +95,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/README.md#unauthorized-access-to-the-data-exchange-service-istg-des-authz-001).
 
 ### Privilege Escalation (ISTG-WRLS-AUTHZ-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -136,6 +139,7 @@ This test case is based on: [ISTG-DES-AUTHZ-002](../data_exchange_services/READM
 Wireless interface might disclose various information, which could reveal details regarding the inner workings of the device or the surrounding IoT ecosystem to potential attackers. This could enable and facilitate further, more advanced attacks.
 
 ### Disclosure of Implementation Details (ISTG-WRLS-INFO-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -181,6 +185,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-of-implementation-details-istg-fw-info-002).
 
 ### Disclosure of Ecosystem Details (ISTG-WRLS-INFO-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -220,6 +225,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-of-ecosystem-details-istg-fw-info-003).
 
 ### Disclosure of User Data (ISTG-WRLS-INFO-003)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -263,6 +269,7 @@ This test case is based on: [ISTG-FW[INST]-INFO-001](../firmware/installed_firmw
 Since IoT devices can have a long lifespan, it is important to make sure that the software, running on the device, is regularly updated in order to apply the latest security patches. The update process of the firmware itself will be covered by [ISTG-FW[UPDT]](../firmware/firmware_update_mechanism.md). However, it must also be verified that software packages, which are running on the device and listening on interfaces, are up-to-date as well.
 
 ### Usage of Outdated Software (ISTG-WRLS-CONF-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -306,6 +313,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-outdated-software-istg-fw-conf-001).
 
 ### Presence of Unnecessary Software and Functionalities (ISTG-WRLS-CONF-002)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -353,6 +361,7 @@ This test case is based on: [ISTG-FW-CONF-002](../firmware/README.md#presence-of
 IoT devices are often operated outside of the control space of their manufacturer. Still, they need to establish connections to other network nodes within the IoT ecosystem, e.g., to request and receive firmware updates or to send data to a cloud API. Hence, it might be required that the device has to provide some kind of authentication credential or secret. These secrets need to be stored on the device in a secure manner to prevent them from being stolen and used to impersonate the device.
 
 ### Access to Confidential Data (ISTG-WRLS-SCRT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -396,6 +405,7 @@ This test case is based on: [ISTG-DES-SCRT-001](../data_exchange_services/README
 Many IoT devices need to implement cryptographic algorithms, e.g., to securely store sensitive data, for authentication purposes or to receive and verify encrypted data from other network nodes. Failing to implement secure, state of the art cryptography might lead to the exposure of sensitive data, device malfunctions or loss of control over the device.
 
 ### Usage of Weak Cryptographic Algorithms (ISTG-WRLS-CRYPT-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -445,6 +455,7 @@ This test case is based on: [ISTG-FW-CRYPT-001](../firmware/README.md#usage-of-w
 Even if all other aspects of the wireless interface are securely implemented and configured, issues in the underlying logic itself might render the device vulnerable to attacks. Thus, it must be verified if the wireless interface and its functionalities are working as intended and if exceptions are detected and properly handled.
 
 ### Circumvention of the Intended Business Logic (ISTG-WRLS-LOGIC-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -488,6 +499,7 @@ This test case is based on: [ISTG-DES-LOGIC-001](../data_exchange_services/READM
 In order to ensure that only valid and well-formed data enters the processing flows of a device, the input from a all untrustworthy sources, e.g., users or external systems, has to be verified and validated.
 
 ### Insufficient Input Validation (ISTG-WRLS-INPV-001)
+
 **Required Access Levels**
 
 <table width="100%">
@@ -527,6 +539,7 @@ For this test case, data from the following sources was consolidated:
 This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README.md#insufficient-input-validation-istg-des-inpv-001).
 
 ### Code or Command Injection (ISTG-WRLS-INPV-002)
+
 **Required Access Levels**
 
 <table width="100%">


### PR DESCRIPTION
## Summary

- close the 11 missing `</td>` tags in authorization rows
- add the missing blank line after 55 test-case headings
- keep the change limited to the five component README files named in the issue

## Verification

- `grep -rn "</i></tr>" src/` → no matches
- the issue's heading-spacing `awk` check → no output
- `bash ./scripts/mdbook_prepare.sh && mdbook build && bash ./scripts/mdbook_cleanup.sh` with the CI-pinned mdBook 0.4.40 → passed
- `git diff --check` → passed

Closes #39

<sub>Submitted from an openly autonomous, AI-assisted contributor account; the edits and checks above are reproducible.</sub>
