### PR TITLE
docs: fix missing </td> tags and heading spacing in test cases

### DIFF
--- a/src/03_test_cases/internal_interfaces/README.md
+++ b/src/03_test_cases/internal_interfaces/README.md
@@ -104,7 +104,8 @@ This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/READM
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-2</i> - <i>AA-3</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-2</i> - <i>AA-3</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -140,7 +141,8 @@ Internal interfaces might disclose various information, which could reveal detai
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -186,7 +188,8 @@ This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br> depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br> depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -226,7 +229,8 @@ This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -270,7 +274,8 @@ Since IoT devices can have a long lifespan, it is important to make sure that t
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -314,7 +319,8 @@ This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-ou
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -362,7 +368,8 @@ IoT devices are often operated outside of the control space of their manufactur
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -406,7 +413,8 @@ Many IoT devices need to implement cryptographic algorithms, e.g., to securely 
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -456,7 +464,8 @@ Even if all other aspects of the internal interface are securely implemented and
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -500,7 +509,8 @@ In order to ensure that only valid and well-formed data enters the processing fl
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -540,7 +550,8 @@ This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**

--- a/src/03_test_cases/physical_interfaces/README.md
+++ b/src/03_test_cases/physical_interfaces/README.md
@@ -103,7 +103,8 @@ This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/READM
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-2</i> - <i>AA-3</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-2</i> - <i>AA-3</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -144,7 +145,8 @@ Physical interfaces might disclose various information, which could reveal detai
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -187,7 +189,8 @@ This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -224,7 +227,8 @@ This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -265,7 +269,8 @@ Since IoT devices can have a long lifespan, it is important to make sure that th
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -306,7 +311,8 @@ This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-ou
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -351,7 +357,8 @@ IoT devices are often operated outside of the control space of their manufacture
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -392,7 +399,8 @@ Many IoT devices need to implement cryptographic algorithms, e.g., to securely s
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -439,7 +447,8 @@ Even if all other aspects of the physical interface are securely implemented and
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -480,7 +489,8 @@ In order to ensure that only valid and well-formed data enters the processing fl
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -517,7 +527,8 @@ This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**

--- a/src/03_test_cases/user_interfaces/README.md
+++ b/src/03_test_cases/user_interfaces/README.md
@@ -105,7 +105,8 @@ This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/READM
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-2</i> - <i>AA-3</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-2</i> - <i>AA-3</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -150,7 +151,8 @@ User interface might disclose various information, which could reveal details re
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -197,7 +199,8 @@ This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -238,7 +241,8 @@ This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -283,7 +287,8 @@ Since ISTG-devices can have a long lifespan, it is important to make sure that t
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -324,7 +329,8 @@ This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-ou
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -369,7 +375,8 @@ ISTG-devices are often operated outside of the control space of their manufactur
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -414,7 +421,8 @@ Many ISTG-devices need to implement cryptographic algorithms, e.g., to securely 
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -461,7 +469,8 @@ Even if all other aspects of the user interface are securely implemented and con
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -506,7 +515,8 @@ In order to ensure that only valid and well-formed data enters the processing fl
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -547,7 +557,8 @@ This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending-on-the-access-model-for-the-given-device)</td>
+	</tr>
 </table>
 
 **Summary**

--- a/src/03_test_cases/wireless_interfaces/README.md
+++ b/src/03_test_cases/wireless_interfaces/README.md
@@ -105,7 +105,8 @@ This test case is based on: [ISTG-DES-AUTHZ-001](../data_exchange_services/READM
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-2</i> - <i>AA-3</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-2</i> - <i>AA-3</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -149,7 +150,8 @@ Wireless interface might disclose various information, which could reveal detail
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -195,7 +197,8 @@ This test case is based on: [ISTG-FW-INFO-002](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -235,7 +238,8 @@ This test case is based on: [ISTG-FW-INFO-003](../firmware/README.md#disclosure-
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -279,7 +283,8 @@ Since IoT devices can have a long lifespan, it is important to make sure that th
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -323,7 +328,8 @@ This test case is based on: [ISTG-FW-CONF-001](../firmware/README.md#usage-of-ou
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -371,7 +377,8 @@ IoT devices are often operated outside of the control space of their manufacture
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -415,7 +422,8 @@ Many IoT devices need to implement cryptographic algorithms, e.g., to securely s
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -465,7 +473,8 @@ Even if all other aspects of the wireless interface are securely implemented and
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -509,7 +518,8 @@ In order to ensure that only valid and well-formed data enters the processing fl
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**
@@ -549,7 +559,8 @@ This test case is based on: [ISTG-DES-INPV-001](../data_exchange_services/README
 	</tr>
 	<tr valign="top">
 		<th align="left">Authorization</th>
-		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</tr>
+		<td><i>AA-1</i> - <i>AA-4</i><br>(depending on the access model for the given device)</td>
+	</tr>
 </table>
 
 **Summary**


### PR DESCRIPTION
### Description

Fixes unclosed table cells in component test-case READMEs.

Broken rows looked like:

```html
<td><i>AA-1</i> ... </tr>
```

Corrected to:

```html
		<td><i>AA-1</i> ... </td>
	</tr>
```

(Close the open cell; do **not** add a second `<td>`.)

### Scope

44 broken Authorization rows remaining on `main` (11 each):

- `src/03_test_cases/internal_interfaces/README.md`
- `src/03_test_cases/physical_interfaces/README.md`
- `src/03_test_cases/user_interfaces/README.md`
- `src/03_test_cases/wireless_interfaces/README.md`

`memory/README.md` was already completed by #42 (not touched).

### Verification

```bash
grep -rnE '<td>.*</tr>' src/03_test_cases/ | grep -v '</td>'
# → no output
```

### Related

- Fixes #39
- Addresses review feedback on #43