### PR TITLE
Reject duplicate chapter numbers instead of silently dropping a section

### DIFF
--- a/.github/workflows/create-checklists.yml
+++ b/.github/workflows/create-checklists.yml
@@ -1,9 +1,16 @@
 name: Create checklists
 
 on:
-  # Runs on pushes targeting the main branch, only if md-files in the test case directory were changed
+  # Regenerates and commits the checklists when test cases change on main
   push:
     branches: [ "main" ]
+    paths: [ "src/03_test_cases/**.md" ]
+
+  # On pull requests the generator runs as a validation step only, without
+  # committing. This catches errors that would otherwise not surface until after
+  # merge — most importantly two test case files declaring the same chapter
+  # number, which the generator now rejects.
+  pull_request:
     paths: [ "src/03_test_cases/**.md" ]
 
   # Allows to run this workflow manually from the actions tab
@@ -12,16 +19,17 @@ on:
 permissions:
   contents: write
 
-# Serialise runs of THIS workflow only, so two runs cannot race on the push
-# below. This must not share a group with the Pages deployment: a concurrency
-# group holds at most one running plus one pending run, and a newly queued run
-# evicts the pending one regardless of cancel-in-progress, so sharing a group
-# meant a burst of merges could cancel the site deployment entirely.
+# Serialise runs of THIS workflow per ref, so two runs on the same branch cannot
+# race on the push below, while runs for different pull requests stay
+# independent. This must not share a group with the Pages deployment: a
+# concurrency group holds at most one running plus one pending run, and a newly
+# queued run evicts the pending one regardless of cancel-in-progress, so sharing
+# a group meant a burst of merges could cancel the site deployment entirely.
 #
 # Losing an intermediate run here is harmless, because the generator rebuilds
 # the checklists from the current source rather than amending previous output.
 concurrency:
-  group: "create-checklists"
+  group: "create-checklists-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:
@@ -40,7 +48,11 @@ jobs:
     - name: Run script
       run: |
         python3 scripts/create_checklists.py
+    # Only commit on main. On a pull request the step above is the whole point:
+    # it either succeeds or fails the check. Committing would also fail anyway,
+    # since GITHUB_TOKEN is read-only for pull requests raised from forks.
     - name: Commit and push
+      if: github.event_name != 'pull_request'
       uses: EndBug/add-and-commit@v10
       with:
         message: Update checklists

--- a/.github/workflows/create-checklists.yml
+++ b/.github/workflows/create-checklists.yml
@@ -1,17 +1,31 @@
 name: Create checklists
 
 on:
-  # Regenerates and commits the checklists when test cases change on main
+  # Regenerates and commits the checklists when any generator input changes on
+  # main. The checklists are derived from the test cases, the generator and the
+  # two templates, so watching only the test cases leaves the committed output
+  # stale after a change to either of the others. GitHub Actions does not
+  # support YAML anchors, so the list is repeated for the pull_request trigger.
   push:
     branches: [ "main" ]
-    paths: [ "src/03_test_cases/**.md" ]
+    paths:
+      - "src/03_test_cases/**.md"
+      - "scripts/create_checklists.py"
+      - "scripts/checklist_template.md"
+      - "scripts/checklist_template.xlsx"
+      - ".github/workflows/create-checklists.yml"
 
   # On pull requests the generator runs as a validation step only, without
   # committing. This catches errors that would otherwise not surface until after
   # merge — most importantly two test case files declaring the same chapter
   # number, which the generator now rejects.
   pull_request:
-    paths: [ "src/03_test_cases/**.md" ]
+    paths:
+      - "src/03_test_cases/**.md"
+      - "scripts/create_checklists.py"
+      - "scripts/checklist_template.md"
+      - "scripts/checklist_template.xlsx"
+      - ".github/workflows/create-checklists.yml"
 
   # Allows to run this workflow manually from the actions tab
   workflow_dispatch:

--- a/scripts/create_checklists.py
+++ b/scripts/create_checklists.py
@@ -124,9 +124,26 @@ def parse_file(filepath):
 
 
 def sort_ids_by_chapter(content):
-    sorted_content = {}
-    for id in content: sorted_content[content[id]["chapter"]] = id
-    return dict(sorted(sorted_content.items())).values()
+    # sort on the chapter number as integers, so that "3.5.10." follows "3.5.9."
+    # rather than preceding "3.5.2." as it would under a string comparison
+    def chapter_key(id):
+        return tuple(int(part) for part in content[id]["chapter"].strip(".").split("."))
+
+    # fail loudly on duplicate chapter numbers. this function previously built a
+    # dict keyed by chapter, so two entries sharing a number silently overwrote
+    # each other and one disappeared from the checklist with no warning
+    seen = {}
+    for id in content:
+        chapter = content[id]["chapter"]
+        if chapter in seen:
+            raise ValueError(
+                f"duplicate chapter number {chapter} used by both {seen[chapter]} and {id}. "
+                "specialization numbers are assigned append-on-merge, so take the next "
+                "free number: CONTRIBUTING.md#section-numbering-for-specializations"
+            )
+        seen[chapter] = id
+
+    return sorted(content, key=chapter_key)
 
 
 def export_test_cases_markdown(test_case_catalog, checklist=CHECKLIST_MARKDOWN, checklist_template=CHECKLIST_TEMPLATE_MARKDOWN):


### PR DESCRIPTION
## The bug

`sort_ids_by_chapter()` built a dict keyed by each entry's chapter number:

```python
sorted_content = {}
for id in content: sorted_content[content[id]["chapter"]] = id
```

Two files declaring the same chapter number overwrote each other, and one vanished from the checklist with no error and no warning.

The section that disappears is not necessarily the incoming one. #20 declares `3.5.2.`, which UART already holds on `main`. Applying #20's head to `main` and regenerating removes UART:

| | `main` | after #20 |
|-|-|-|
| UART lines in `checklist.md` | 9 | 0 |
| UART rows in `checklist.xlsx` | 5 | 0 |
| generator exit status | 0 | 0 |

Five test cases, gone, on a green build.

#32 declared `3.5.1.` until recently and now declares `3.5.3.` — caught by a reviewer, not the build. #33 documented the numbering collision but not that its consequence was data loss.

## Changes

`scripts/create_checklists.py` sorts the ids directly and raises on a duplicate:

```
ValueError: duplicate chapter number 3.5.2. used by both ISTG-INT[UART] and ISTG-INT[SPI].
specialization numbers are assigned append-on-merge, so take the next free number:
CONTRIBUTING.md#section-numbering-for-specializations
```

The message names the convention because an outside contributor will hit this before a maintainer does. Chapter numbers are also compared as integer tuples, so `3.5.10.` sorts after `3.5.9.` instead of before `3.5.2.`

`.github/workflows/create-checklists.yml` runs the generator on pull requests as a validation step without committing, so a collision fails a check during review rather than after merge. The commit step is guarded on the event name, also necessary because `GITHUB_TOKEN` is read-only for pull requests from forks. The concurrency group is scoped per ref so runs for different pull requests do not evict one another, the same failure mode fixed in #37.

The second commit widens the trigger paths. The checklists are derived from four inputs — the test cases, `create_checklists.py`, `checklist_template.md` and `checklist_template.xlsx` — and both triggers watched only the first. On `main` that leaves the committed checklists stale after a change to the generator or either template, until someone happens to touch a test case. On pull requests it means a change to the generator is never exercised: this PR's first commit added a new failure mode to `sort_ids_by_chapter()` and triggered no checks at all.

No changes under `checklists/`.

## #38

The integer sort key closes #38. Its diagnosis is wrong: it reports that specializations are emitted in `os.walk` order, but `sort_ids_by_chapter()` already applied to them (`main` lines 159 and 206), sorting by chapter as a string. String order holds up to nine specializations, so the mismatch #38 predicts for JTAG and SPI would not have occurred. The defect is the tenth.

## Verification

Against unchanged content the output is unchanged:

- `checklist.md` byte-identical
- `checklist.xlsx` cell-identical, 612 cells, 0 differences (the byte diff is zip timestamps)

Applying #20's head to `main`:

- current generator — exit 0, UART dropped
- this branch — `ValueError`, build fails, both colliding IDs named

Ordering: `3.5.1.`, `3.5.2.`, `3.5.9.`, `3.5.10.` sort in that order.

Closes #38. Relates to #33. Unblocks #20 and #32.

## Not addressed

Document position is declared twice — the `3.5.x` number in each file's H1, and the line's position in `SUMMARY.md` — and nothing validates that they agree. This guards the first against collisions. The drift between them needs a separate issue.
