### PR TITLE
docs: rewrite versioning.md for trunk-based release flow

### DIFF
--- a/versioning.md
+++ b/versioning.md
@@ -4,19 +4,20 @@
 
 The version structure for this project is defined as follows:
 
-1. **MAJOR version:** Major versions consolidate extensive changes to multiple parts of the guide (e.g., framework changes, multiple new/updated [components / component specializations](./src/02_framework/methodology#structure-of-the-catalog-of-test-cases), greater depth of detail for a considerable amount of test cases).
-2. **MINOR version:** Minor versions are released once a [components / component specializations](./src/02_framework/methodology#structure-of-the-catalog-of-test-cases) has been added or extensively updated/refined.
-3. **PATCH version:** Patch version releases are used for smaller fixes (bugs, typos, issues). 
+1. **MAJOR version:** Major versions consolidate extensive changes to multiple parts of the guide (for example, framework changes, multiple new or updated [components or component specializations](./src/02_framework/methodology.md#structure-of-the-catalog-of-test-cases), or substantially deeper coverage across many test cases).
+2. **MINOR version:** Minor versions are released when a [component or component specialization](./src/02_framework/methodology.md#structure-of-the-catalog-of-test-cases) is added or extensively updated or refined.
+3. **PATCH version:** Patch version releases are used for smaller fixes (bugs, typos, issues).
 
 Each release will be tagged with a version identifier "*v[MAJOR].[MINOR].[PATCH]*".
 
 
 
-## Branch Structure
+## Development and Release Flow
 
-The following branch structure has been defined:
+The project uses trunk-based development:
 
-- **main:** Latest release version
-- **latest:** Main working branch that includes all finished but unreleased changes
-- **istg-[component_id]:** Used for adding/updating parts of [components / component specializations](./src/02_framework/methodology#structure-of-the-catalog-of-test-cases)
-- Further branches will be created for individual topics. Self-explanatory names should be used.
+- **`main`:** The working branch containing merged changes, including changes not yet released.
+- **Release tags:** Stable releases are commits on `main` tagged with their version identifier.
+- **Contribution branches:** Use short-lived, descriptive branches for individual changes. A branch that adds or updates a [component or component specialization](./src/02_framework/methodology.md#structure-of-the-catalog-of-test-cases) may use the `istg-[component_id]` pattern.
+
+Finished changes merge into `main` through pull requests. The repository does not use a separate `latest` working branch; release tags identify the commits published as stable guide versions.


### PR DESCRIPTION
## What

Corrects `versioning.md` to match how the repository is actually developed, per
the versioning checklist item in issue #40.

- Removes the nonexistent `latest` working branch and the claim that `main` is
  the "latest release version"; `main` is the working branch holding merged but
  unreleased changes.
- Documents trunk-based development: short-lived contribution branches,
  pull-request merges to `main`, and version tags marking stable releases.
- Fixes the three local links to
  `src/02_framework/methodology.md#structure-of-the-catalog-of-test-cases`
  (the previous extensionless paths did not resolve) and corrects the grammar in
  the MAJOR / MINOR / PATCH definitions.

Refs #40
